### PR TITLE
Fix reserved word 'type' issue

### DIFF
--- a/lib/lifx/message.rb
+++ b/lib/lifx/message.rb
@@ -30,14 +30,14 @@ module LIFX
 
         message = Protocol::Message.read(data)
         path = ProtocolPath.new(raw_site: message.raw_site, raw_target: message.raw_target, tagged: message.tagged)
-        payload_class = message_type_for_id(message.type.snapshot)
+        payload_class = message_type_for_id(message.type_.snapshot)
         if payload_class.nil?
           if Config.log_invalid_messages
-            logger.error("Message.unpack: Unrecognised payload ID: #{message.type}")
+            logger.error("Message.unpack: Unrecognised payload ID: #{message.type_}")
             logger.error("Message.unpack: Message: #{message}")
           end
           return nil # FIXME
-          raise UnmappedPayload.new("Unrecognised payload ID: #{message.type}")
+          raise UnmappedPayload.new("Unrecognised payload ID: #{message.type_}")
         end
         begin
           payload = payload_class.read(message.payload)
@@ -117,7 +117,7 @@ module LIFX
       if type_id.nil?
         raise UnmappedPayload.new("Unmapped payload class #{payload.class}")
       end
-      @message.type = type_id
+      @message.type_ = type_id
       @message.payload = payload.pack
     end
 
@@ -138,7 +138,7 @@ module LIFX
       else
         hash[:device] = path.device_id
       end
-      hash[:type] = payload.class.to_s.sub('LIFX::Protocol::', '')
+      hash[:type_] = payload.class.to_s.sub('LIFX::Protocol::', '')
       hash[:addressable] = addressable? ? 'true' : 'false'
       hash[:tagged] = path.tagged? ? 'true' : 'false'
       hash[:at_time] = @message.at_time if @message.at_time && @message.at_time > 0

--- a/lib/lifx/protocol/metadata.rb
+++ b/lib/lifx/protocol/metadata.rb
@@ -4,9 +4,9 @@ module LIFX
       def MetadataFields.included(mod)
         mod.instance_eval do
           hide :_reserved3
-          
+
           uint64 :at_time
-          uint16 :type
+          uint16 :type_
           uint16 :_reserved3
         end
       end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -34,7 +34,7 @@ describe LIFX::Message do
 
     it 'returns the correct metadata' do
       expect(msg.at_time).to eq 0
-      expect(msg.type).to eq 103
+      expect(msg.type_).to eq 103
     end
 
     let(:payload) { msg.payload }
@@ -110,7 +110,7 @@ describe LIFX::Message do
         expect(msg).to be_addressable
         expect(msg.path.raw_target).to eq 'abcdefgh'
         expect(msg.at_time).to eq 9001
-        expect(msg.type).to eq 305
+        expect(msg.type_).to eq 305
         expect(msg.payload.class).to eq LIFX::Protocol::Wifi::SetAccessPoint
         expect(msg.payload.interface).to eq 1
         expect(msg.payload.ssid).to eq 'who let the dogs out'


### PR DESCRIPTION
'Gem Load Error is: field 'type' is a reserved name in LIFX::Protocol::Metadata'
error was observed with Ruby 2.4.2. This patch changes specs and the code to
get rid of the message.