### PR TITLE
Constant ::TimeoutError is deprecated

### DIFF
--- a/lib/lifx/client.rb
+++ b/lib/lifx/client.rb
@@ -40,7 +40,7 @@ module LIFX
       @context.discover
     end
 
-    class DiscoveryTimeout < TimeoutError; end
+    class DiscoveryTimeout < Timeout::Error; end
     # This method tells the {NetworkContext} to look for devices, and will block
     # until there's at least one device.
     #

--- a/lib/lifx/light.rb
+++ b/lib/lifx/light.rb
@@ -363,7 +363,7 @@ module LIFX
     end
 
     # An exception for when synchronous messages take too long to receive a response
-    class MessageTimeout < TimeoutError
+    class MessageTimeout < Timeout::Error
       attr_accessor :device
     end
 


### PR DESCRIPTION
Replaced with Timeout::Error