### PR TITLE
Add #location and #group info methods to Lights

### DIFF
--- a/lib/lifx/lan/light.rb
+++ b/lib/lifx/lan/light.rb
@@ -334,6 +334,26 @@ module LIFX
         context.tags_for_device(self)
       end
 
+      def location
+        send_message!(Protocol::Device::GetLocation.new,
+            wait_for: Protocol::Device::StateLocation) do |payload|
+          {
+            location: payload.location,
+            label: payload.label
+          }
+        end
+      end
+
+      def group
+        send_message!(Protocol::Device::GetGroup.new,
+            wait_for: Protocol::Device::StateGroup) do |payload|
+          {
+            group: payload.group,
+            label: payload.label
+          }
+        end
+      end
+
       # Returns whether the light is a gateway
       # @api private
       def gateway?


### PR DESCRIPTION
Just implements the `Protocol::Device::GetLocation`/`Protocol::Device::StateLocation` and `Protocol::Device::GetGroup`/`Protocol::Device::StateGroup` pairs.

Maybe useful to organize lights by group and location, example:
```
lifx = LIFX::LAN::Client.lan
lifx.discover!
lights = lifx.lights.to_a
located_lights = lights.each_with_object(Hash.new {|h,k| h[k] = [] }) do |light, located|
  located["#{light.location[:label]} - #{light.group[:label]}"] << light
end
```